### PR TITLE
Unique reference validation.

### DIFF
--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -16,6 +16,7 @@ class Customer < ActiveRecord::Base
     :reference,
     :uuid,
     :presence => true
+  validates :reference, :uniqueness => true
 
   def active?
     is_active == 1 ? true : false

--- a/app/models/entity.rb
+++ b/app/models/entity.rb
@@ -20,6 +20,7 @@ class Entity < ActiveRecord::Base
     :reference,
     :uuid,
     :presence => true
+  validates :reference, :uniqueness => true
 
   def to_s
     name

--- a/app/models/salesperson.rb
+++ b/app/models/salesperson.rb
@@ -14,6 +14,7 @@ class Salesperson < ActiveRecord::Base
     :reference,
     :uuid,
     :presence => true
+  validates :reference, :uniqueness => true
 
   def active?
     is_active == 1 ? true : false

--- a/app/models/vendor.rb
+++ b/app/models/vendor.rb
@@ -14,6 +14,7 @@ class Vendor < ActiveRecord::Base
     :reference,
     :uuid,
     :presence => true
+  validates :reference, :uniqueness => true
 
   def active?
     is_active == 1 ? true : false

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Customer, :type => :model do
+  subject { build(:customer, :entity => create(:entity)) }
+
   describe 'associations' do
     it { is_expected.to belong_to(:default_contact) }
     it { is_expected.to belong_to(:default_location) }
@@ -14,6 +16,7 @@ RSpec.describe Customer, :type => :model do
     it { is_expected.to validate_presence_of(:is_active) }
     it { is_expected.to validate_presence_of(:reference) }
     it { is_expected.to validate_presence_of(:uuid) }
+    it { is_expected.to validate_uniqueness_of(:reference) }
   end
 
   describe '#active?' do

--- a/spec/models/entity_spec.rb
+++ b/spec/models/entity_spec.rb
@@ -14,5 +14,6 @@ RSpec.describe Entity, :type => :model do
     it { is_expected.to validate_presence_of(:cached_long_name) }
     it { is_expected.to validate_presence_of(:reference) }
     it { is_expected.to validate_presence_of(:uuid) }
+    it { is_expected.to validate_uniqueness_of(:reference) }
   end
 end

--- a/spec/models/salesperson_spec.rb
+++ b/spec/models/salesperson_spec.rb
@@ -2,7 +2,11 @@ require 'rails_helper'
 
 RSpec.describe Salesperson, :type => :model do
   let(:default_location) { nil }
-  subject { build(:salesperson, :default_location => default_location) }
+  subject do
+    build(:salesperson,
+          :default_location => default_location,
+          :entity => create(:entity))
+  end
 
   describe 'associations' do
     it { is_expected.to belong_to(:default_location) }
@@ -13,6 +17,7 @@ RSpec.describe Salesperson, :type => :model do
     it { is_expected.to validate_presence_of(:entity) }
     it { is_expected.to validate_presence_of(:reference) }
     it { is_expected.to validate_presence_of(:uuid) }
+    it { is_expected.to validate_uniqueness_of(:reference) }
   end
 
   describe '.active' do

--- a/spec/models/vendor_spec.rb
+++ b/spec/models/vendor_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Vendor, :type => :model do
+  subject { build(:vendor, :entity => create(:entity)) }
+
   describe 'associations' do
     it { is_expected.to belong_to(:default_contact) }
     it { is_expected.to belong_to(:default_location) }
@@ -12,6 +14,7 @@ RSpec.describe Vendor, :type => :model do
     it { is_expected.to validate_presence_of(:is_active) }
     it { is_expected.to validate_presence_of(:reference) }
     it { is_expected.to validate_presence_of(:uuid) }
+    it { is_expected.to validate_uniqueness_of(:reference) }
   end
 
   describe '#active?' do


### PR DESCRIPTION
Prevent reference values from being duplicate across Entity and Entity traits.
 - Although traits may reuse references of different traits.
 - Closes #52.